### PR TITLE
transform file.path by configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ module.exports = function(config) {
       // strip this to the file path \ fixture name
       prependPrefix: 'mock/',
       // change the global fixtures variable name
-      variableName: '__mocks__'
+      variableName: '__mocks__',
+      // transform the filename
+      transformPath: function(path) {
+        return path + '.js';
+      }
     }
   });
 };

--- a/json_fixtures.js
+++ b/json_fixtures.js
@@ -16,6 +16,10 @@ module.exports = (function () {
         var stripPrefix = new RegExp('^' + (config.stripPrefix || '')),
             prependPrefix = config.prependPrefix || '';
 
+        var transformPath = config.transformPath || function(filepath) {
+                return filepath.replace(/\.json$/, '.js');
+            };
+
         return function (content, file, done) {
             var fixtureName = file.originalPath
                 .replace(basePath + '/', '')
@@ -27,7 +31,8 @@ module.exports = (function () {
             // Update the fixture name
             fixtureName = prependPrefix + fixtureName.replace(stripPrefix, '');
 
-            file.path = file.path.replace(/\.json$/, '.js');
+            // transform file path
+            file.path = transformPath(file.path);
 
             done(util.format(template, fixtureName, content));
         };


### PR DESCRIPTION
In some cases there is a need to transform `file.path` to another value than `any/path/file.js`. For example if a processor do need to check of a `.json` file extension such as  [karma-fixture](https://github.com/billtrik/karma-fixture)